### PR TITLE
Numeric Comparisons for Rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Create a config.json file in the root directory
   "prefix": "set to whichever prefix you wish the bot to use.",
   "token": "set to your discord bot API token",
   "movieDbAPI": "set to your API token from developers.themoviedb.org (Required to get movie data when requested by user)",
-  "mongoLogin": "set to your connection string for any MongoDB collection (Check Mongoose for more information)"
+  "mongoLogin": "set to your connection string for any MongoDB collection (Check Mongoose for more information)",
+  "topggAPI": "Top.gg Api Key (Optional if testing=true)",
+  "testing": "set to true if you do not want to use top.gg/dblapi.js."
 }
 ```
 

--- a/bot.js
+++ b/bot.js
@@ -351,7 +351,12 @@ function getSettings(guildID) {
 	return setting.findOne({guildID: guildID }).lean().exec();
 }
 
-function buildComparison(comparison) {
+/**
+ * Builds a Mongoose comparison object based on a given string.
+ * @param string comparison A string of length > 0 which contains either a number, or a number and 
+ * a comparison operator.
+ */
+function buildNumericComparison(comparison) {
 	let operator = comparison.charAt(0);
 	switch(operator) {
 		case '<':
@@ -365,8 +370,9 @@ function buildComparison(comparison) {
 			break;
 		default:
 			operator = "$gt";
+			
 	}
-	return { [operator]: parseFloat(comparison.replace(/[^\d.-]/g, ''))}
+	return { [operator]: comparison.replace(/[^\d.-]/g, '') }
 }
 
 // function syncUpAfterDowntime() {
@@ -388,7 +394,7 @@ function buildComparison(comparison) {
 main.movieModel = movieModel;
 main.searchMovieDatabaseObject = searchMovieDatabaseObject;
 main.buildSingleMovieEmbed = buildSingleMovieEmbed;
-main.buildComparison = buildComparison;
+main.buildNumericComparison = buildNumericComparison;
 main.searchNewMovie = searchNewMovie;
 main.setting = setting;
 main.guildSettings = guildSettings;

--- a/bot.js
+++ b/bot.js
@@ -372,7 +372,8 @@ function buildNumericComparison(comparison) {
 			operator = "$gt";
 			
 	}
-	return { [operator]: comparison.replace(/[^\d.-]/g, '') }
+	const value = parseFloat(comparison.replace(/[^\d.-]/g, ''));
+	return (value != '' && !isNaN(value)) ? { [operator]: value } : null;
 }
 
 // function syncUpAfterDowntime() {

--- a/bot.js
+++ b/bot.js
@@ -248,7 +248,7 @@ function handleError(err, message) {
 }
 
 //Movie can be string or IMDB link
-function searchMovieDatabaseObject(guildID, movie, hideViewed) {
+function searchMovieDatabaseObject(guildID, movie, hideViewed, rating) {
 	var searchObj = {
 		guildID: guildID
 	};
@@ -259,6 +259,10 @@ function searchMovieDatabaseObject(guildID, movie, hideViewed) {
 
 	if (hideViewed) {
 		searchObj.viewed = false;
+	}
+
+	if (rating) {
+		searchObj.rating = rating;
 	}
 
 	return searchObj;
@@ -347,6 +351,24 @@ function getSettings(guildID) {
 	return setting.findOne({guildID: guildID }).lean().exec();
 }
 
+function buildComparison(comparison) {
+	let operator = comparison.charAt(0);
+	switch(operator) {
+		case '<':
+			operator = "$lt";
+			break;
+		case '>':
+			operator = "$gt";
+			break;
+		case '=':
+			operator ="$eq";
+			break;
+		default:
+			operator = "$gt";
+	}
+	return { [operator]: parseFloat(comparison.replace(/[^\d.-]/g, ''))}
+}
+
 // function syncUpAfterDowntime() {
 // 	setting.find({}).exec(function(err, docs) { 
 // 		var missingSettings = Array.from(client.guilds.cache.keys()).filter(function(val) {
@@ -366,6 +388,7 @@ function getSettings(guildID) {
 main.movieModel = movieModel;
 main.searchMovieDatabaseObject = searchMovieDatabaseObject;
 main.buildSingleMovieEmbed = buildSingleMovieEmbed;
+main.buildComparison = buildComparison;
 main.searchNewMovie = searchNewMovie;
 main.setting = setting;
 main.guildSettings = guildSettings;

--- a/commands/add.js
+++ b/commands/add.js
@@ -21,9 +21,9 @@ module.exports = {
 			return main.searchNewMovie(search, message, function(newMovie, data) {
 				//No need for else, searchNewMovie alerts user if no movie found.
 				if (newMovie) {
-					newMovie.save(function(err) {
+				newMovie.save(function(err) {
 						if (err && err.name == "MongoError") {
-							message.channel.send("Movie already exists in the list. It may be marked as 'Viewed'");
+							message.channel.send(newMovie.name + " already exists in the list. It may be marked as 'Viewed'");
 
 							return callback();
 						}
@@ -50,16 +50,16 @@ module.exports = {
 										const reaction = collected.first();
 
 										if (reaction.emoji.name == emojis.yes) {
-											message.channel.send("Movie will be added to the list!");
+											message.channel.send( newMovie.name + " will be added to the list!");
 
 											return callback();
 										} else {
-											message.channel.send("Movie will not be added to the list. Try using an IMDB link instead?");
+											message.channel.send(newMovie.name + " will not be added to the list. Try using an IMDB link instead?");
 											
 											return removeMovie(newMovie, callback);
 										}
 									}).catch(() => {
-										message.channel.send("Movie will not be added, you didn't respond in time. Try using an IMDB link instead?");
+										message.channel.send(newMovie.name + " will not be added, you didn't respond in time. Try using an IMDB link instead?");
 
 										return removeMovie(newMovie, callback);
 									});

--- a/commands/random.js
+++ b/commands/random.js
@@ -6,12 +6,12 @@ module.exports = {
 	async execute(message, args, main, callback, settings) {
 		//If we have arguments, we assume our first argument is a number or a comparison operator and a number.
 		const rating = args.length > 0 ? main.buildNumericComparison(args.join(" ")) : null;
+
+		const searchOptions = main.searchMovieDatabaseObject(message.guild.id, "", true, rating);
 		//First we get total number of movies the guild has that are unviewed.
-		return main.movieModel.countDocuments({guildID: message.guild.id, viewed: false, rating}, function(err, count) {
+		return main.movieModel.countDocuments(searchOptions, function(err, count) {
 			if (!err) {
 				const random = Math.floor(Math.random() * count);
-				const searchOptions = main.searchMovieDatabaseObject(message.guild.id, "", true, rating);
-
 				//Then using a generated random number limited to the count, we find a random movie from the guilds list. If auto view is on, it will be set to viewed.
 				return main.movieModel.find(searchOptions).skip(random).limit(1).lean().exec(async function (error, docs) {
 					if (docs && docs.length > 0) {

--- a/commands/random.js
+++ b/commands/random.js
@@ -5,10 +5,11 @@ module.exports = {
 	admin: true,
 	async execute(message, args, main, callback, settings) {
 		//First we get total number of movies the guild has that are unviewed.
-		return main.movieModel.countDocuments({guildID: message.guild.id, viewed: false }, function(err, count) {
+		const rating = args.length > 0 ? main.buildComparison(args[0]) : null;
+		return main.movieModel.countDocuments({guildID: message.guild.id, viewed: false, rating}, function(err, count) {
 			if (!err) {
 				const random = Math.floor(Math.random() * count);
-				const searchOptions = main.searchMovieDatabaseObject(message.guild.id, "", true);
+				const searchOptions = main.searchMovieDatabaseObject(message.guild.id, "", true, rating);
 
 				//Then using a generated random number limited to the count, we find a random movie from the guilds list. If auto view is on, it will be set to viewed.
 				return main.movieModel.find(searchOptions).skip(random).limit(1).lean().exec(async function (error, docs) {

--- a/commands/random.js
+++ b/commands/random.js
@@ -4,8 +4,9 @@ module.exports = {
 	aliases: ["getrandom", "getone", "randommovie", "roulette"],
 	admin: true,
 	async execute(message, args, main, callback, settings) {
+		//If we have arguments, we assume our first argument is a number or a comparison operator and a number.
+		const rating = args.length > 0 ? main.buildNumericComparison(args.join(" ")) : null;
 		//First we get total number of movies the guild has that are unviewed.
-		const rating = args.length > 0 ? main.buildComparison(args[0]) : null;
 		return main.movieModel.countDocuments({guildID: message.guild.id, viewed: false, rating}, function(err, count) {
 			if (!err) {
 				const random = Math.floor(Math.random() * count);


### PR DESCRIPTION
This implements the ability to have numeric comparisons particularly for rating.

- A new function `buildNumericComparison` has been created which takes in a string of length > 0. _Typically this is input from a command's args_ and transforms it into a Mongoose-consumable object.
- Initial usage is for filtering `random` calls.
  Eg. args: `null`, `<5`, `< 5`, `> 5`.
- Possibly extended to use `>=` -> `$gte`, etc if necessary.
- Small addition to `README.md` with other supported arguments.
- More verbose Discord messages when calling `add`.
- Tries to mimic styling/linting found in the project.