### PR TITLE
Fix response formatting

### DIFF
--- a/Discord Bot/commands/viewed.js
+++ b/Discord Bot/commands/viewed.js
@@ -24,7 +24,7 @@ module.exports = {
 
 			for (let movie of docs) {
 				const stringConcat = `**[${number++}. ${movie.name}](https://www.imdb.com/title/${movie.imdbID})** submitted by ${movie.submittedBy}, viewed on ${moment(movie.viewedDate).format("DD MMM YYYY")}\n
-				**Release Date:** ${moment(movie.releaseDate).format("DD MMM YYYY")} **Runtime:** ${movie.runtime} **Minutes Rating:** ${movie.rating}\n\n`;
+				**Release Date:** ${moment(movie.releaseDate).format("DD MMM YYYY")} **Runtime:** ${movie.runtime} Minutes **Rating:** ${movie.rating}\n\n`;
 
 				//If the length of message has become longer than DISCORD API max, we split the message into a seperate embedded message.
 				if (description.length + stringConcat.length > 2048) {


### PR DESCRIPTION
Fixed minutes being formatted as bold in the response for viewed list.

Before: **Release Date:** 19 Oct 2006 **Runtime:** 130 **Minutes Rating:** 8.2
After: **Release Date:** 19 Oct 2006 **Runtime:** 130 Minutes **Rating:** 8.2
